### PR TITLE
Add numeric font-weight and letter-spacing vars

### DIFF
--- a/index.css
+++ b/index.css
@@ -2,14 +2,17 @@
 
 body {
   font-family: var(--font-family);
+  font-weight: var(--font-weight);
   line-height: var(--line-height);
   font-size: 100%;
+  letter-spacing: var(--letter-spacing);
 }
 
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--heading-font-family);
-  font-weight: var(--heading-font-weight);
+  font-weight: calc(var(--font-weight) + var(--heading-font-extra-weight));
   line-height: var(--heading-line-height);
+  letter-spacing: var(--heading-letter-spacing);
   margin-top: 1em;
   margin-bottom: .5em;
 }
@@ -18,6 +21,10 @@ p, dl, ol, ul {
   font-size: var(--h4);
   margin-top: 0;
   margin-bottom: var(--space-2);
+}
+
+strong, b {
+  font-weight: calc(var(--font-weight) + var(--bold-font-extra-weight));
 }
 
 ol, ul {
@@ -67,9 +74,12 @@ h6, .h6 { font-size: var(--h6) }
 
 :root {
   --font-family: 'Helvetica Neue', Helvetica, sans-serif;
+  --font-weight: 300;
+  --letter-spacing: inherit;
+  --heading-letter-spacing: inherit;
   --line-height: 1.5;
   --heading-font-family: var(--font-family);
-  --heading-font-weight: bold;
+  --heading-font-extra-weight: 200;
   --heading-line-height: 1.25;
   --monospace-font-family: 'Source Code Pro', Consolas, monospace;
   --h1: 2rem;
@@ -78,7 +88,7 @@ h6, .h6 { font-size: var(--h6) }
   --h4: 1rem;
   --h5: .875rem;
   --h6: .75rem;
-  --bold-font-weight: bold;
+  --bold-font-extra-weight: 200;
   --space-1: .5rem;
   --space-2: 1rem;
   --space-3: 2rem;


### PR DESCRIPTION
Came out of something I'm working on where I used Helvetica Neue at weight `300` (light but not ultra-light) with a little bit of spacing between the letters so they don't run directly into each other. Here was my final stylesheet (after this patch):

``` css
@import 'basscss-base-typography';

blockquote {
  font-size: var(--h4);
  margin-top: var(--space-2);
  margin-bottom: var(--space-2);
}

:root {
  --font-weight: 300;
  --letter-spacing: 0.2px;
  --heading-letter-spacing: 0px;
  --heading-extra-weight: 200;
  --monospace-font-family: Inconsolata, Consolas, 'Source Code Pro', monospace;
  --bold-font-weight: bold;
}
```
